### PR TITLE
feat: Add Support for multi arch builds

### DIFF
--- a/cmd/bake.go
+++ b/cmd/bake.go
@@ -16,6 +16,7 @@ var bakeCmd = &cobra.Command{
 		dockerFlag, _ := cmd.Flags().GetBool("d")
 		if dockerFlag {
 			loadDockerEnv(enigmaFile)
+			docker.CreateBuildxInstance()
 			docker.InstallBinfmt()
 			docker.BuildDockerImage()
 			docker.ScanDockerImage()

--- a/cmd/build-publish.go
+++ b/cmd/build-publish.go
@@ -14,6 +14,7 @@ var bake_publishCmd = &cobra.Command{
 		dockerFlag, _ := cmd.Flags().GetBool("d")
 		if dockerFlag {
 			loadDockerEnv(enigmaFile)
+			docker.CreateBuildxInstance()
 			docker.InstallBinfmt()
 			docker.BuildDockerImage()
 			docker.ScanDockerImage()

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -14,6 +14,7 @@ var publishCmd = &cobra.Command{
 		dockerFlag, _ := cmd.Flags().GetBool("d")
 		if dockerFlag {
 			loadDockerEnv(*&enigmaFile)
+			docker.CreateBuildxInstance()
 			docker.InstallBinfmt()
 			docker.TagDockerImage()
 			docker.PushDockerImage()


### PR DESCRIPTION
Here’s a structured summary for the commit titled "Add Support for Multi-Arch Builds":

## What
* Introduced functionality to build Docker images that support multiple architectures (e.g., amd64, arm64).
* Implemented a single command in the CLI to facilitate multi-architecture builds, simplifying the process for developers.

## Why
* Addresses the need for deploying applications across different hardware architectures, enhancing compatibility and user reach.
* Streamlines the development workflow by allowing developers to build and publish multi-arch images with a single command, reducing the complexity of managing separate builds for different architectures.
* Improves deployment efficiency by ensuring that the correct image is used for the target architecture, minimizing runtime errors and compatibility issues.

## References
* Closes #26 
* For further details, refer to the [Docker Multi-Architecture Support Documentation](https://docs.docker.com/buildx/working-with-buildx/#build-multi-architecture-images).